### PR TITLE
refactor: move regex chapter to beginning of part 3

### DIFF
--- a/website/content/docs/part-3-manipulating-text/advanced-text-manipulation/_index.md
+++ b/website/content/docs/part-3-manipulating-text/advanced-text-manipulation/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "Advanced Text Manipulation"
 slug: "advanced-text-manipulation"
-weight: 15
+weight: 16
 ---
 
-# Chapter 15 - Advanced Text Manipulation with Sed
+# Chapter 16 - Advanced Text Manipulation with Sed
 
-In [Chapter 14]({{< relref "/docs/part-3-manipulating-text/slice-and-dice-text" >}}) we introduced some simple commands to work with text - specifically `head`, `tail`, `tr` and `cut`. Now we are going to introduce `sed` the _Stream Editor_ command. 
+In [Chapter 15]({{< relref "/docs/part-3-manipulating-text/slice-and-dice-text" >}}) we introduced some simple commands to work with text - specifically `head`, `tail`, `tr` and `cut`. Now we are going to introduce `sed` the _Stream Editor_ command. 
 
 `sed` can be used to perform a variety of tasks with text. In many cases a small command involving `sed` can quickly solve problems. We'll look at some of the common ways to use `sed`, some more sophisticated examples and discuss when you might want to consider using alternative tools like `awk` or a programming language.
 

--- a/website/content/docs/part-3-manipulating-text/build-commands-on-the-fly/_index.md
+++ b/website/content/docs/part-3-manipulating-text/build-commands-on-the-fly/_index.md
@@ -1,10 +1,10 @@
 ---
 title: "Build Commands on the Fly"
 slug: "build-commands-on-the-fly"
-weight: 16
+weight: 17
 ---
 
-# Chapter 16 - Build Commands on the Fly with Xargs
+# Chapter 17 - Build Commands on the Fly with Xargs
 
 In the earlier chapters of this part of the book we've seen a number of ways to manipulate text. Now we're going to introduce the `xargs` command and show how to use our text manipulation skills to dynamically build complex commands on the fly.
 

--- a/website/content/docs/part-3-manipulating-text/get-to-grips-with-grep/_index.md
+++ b/website/content/docs/part-3-manipulating-text/get-to-grips-with-grep/_index.md
@@ -1,10 +1,10 @@
 ---
 title: "Get to Grips with Grep"
 slug: "get-to-grips-with-grep"
-weight: 13
+weight: 14
 ---
 
-# Chapter 13 - Get to Grips with Grep
+# Chapter 14 - Get to Grips with Grep
 
 The `grep` tool is a real workhorse for shell users - once you've learned how to use it you will find yourself using it again and again. In this chapter we'll see how you can use `grep` for common tasks, and how to use it in combination with other tools.
 

--- a/website/content/docs/part-3-manipulating-text/regex-essentials/_index.md
+++ b/website/content/docs/part-3-manipulating-text/regex-essentials/_index.md
@@ -1,10 +1,10 @@
 ---
 title: "Regex Essentials"
 slug: "regex-essentials"
-weight: 17
+weight: 13
 ---
 
-# Chapter 17 - Regex Essentials
+# Chapter 13 - Regex Essentials
 
 Many of the tools we're working with support _regular expressions_ or regexes - a sophisticated language which allows us to describe different patterns of text.
 

--- a/website/content/docs/part-3-manipulating-text/slice-and-dice-text/_index.md
+++ b/website/content/docs/part-3-manipulating-text/slice-and-dice-text/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "Slice and Dice Text"
 slug: "slice-and-dice-text"
-weight: 14
+weight: 15
 ---
 
-# Chapter 14 - Slice and Dice Text
+# Chapter 15 - Slice and Dice Text
 
-In [Chapter 13]({{< relref "/docs/part-3-manipulating-text/get-to-grips-with-grep" >}}) we looked at how to use the `grep` command to search through text and filter text. In this chapter we're going to look at some of the basic commands which we can use to _manipulate_ text. There are a whole raft of commands and options available.
+In [Chapter 14]({{< relref "/docs/part-3-manipulating-text/get-to-grips-with-grep" >}}) we looked at how to use the `grep` command to search through text and filter text. In this chapter we're going to look at some of the basic commands which we can use to _manipulate_ text. There are a whole raft of commands and options available.
 
 We'll start with the basics and move onto some of the more sophisticated commands in the next chapter.
 


### PR DESCRIPTION
This makes a lot more sense as we rely on regexes throughout the later
chapters.

❗ Important ❗

Please check the [contributor guide](./CONTRIBUTING.md) when submitting changes. It is important to be aware that the content in this repository may be published in physical book format at a later date. I will try to keep track of all contributions, but by submitting content you must be aware that the content may be used commercially.
