### PR TITLE
Fix footnotes

### DIFF
--- a/docs/01-transitioning-to-the-shell/05-getting-help/index.md
+++ b/docs/01-transitioning-to-the-shell/05-getting-help/index.md
@@ -477,4 +477,3 @@ In this chapter we looked at some of the ways we can get help. To quickly summar
 
 [^1]: Weirdly satisfying to run.
 [^2]: Which it is always fun to try if you get the chance, and a great way to learn more about the fundamentals of the operating system.
-[^3]: Dash is a paid product. Full disclosure - I don't get any money from them or anyone else to write about anything, all content is 100% based on my experiences. I don't run ads on my site either.

--- a/docs/02-core-skills/07-thinking-in-pipelines/index.md
+++ b/docs/02-core-skills/07-thinking-in-pipelines/index.md
@@ -538,7 +538,7 @@ There are a few chapters which are planned to come later which go into detail on
 
 When these chapters are published I'll update the links here. If you want to be updated when new chapters are published, you can [Join the Mailing Lits on the Homepage](https://effective-shell.com).
 
-[^1]: Technically there is another layer here, which is the `tty`. You can see this by running `tty` in the shell. We'll more about this in the [Interlude - What is a Shell](#TODO) section.
+[^1]: Technically there is another layer here, which is the `tty`. You can see this by running `tty` in the shell. We'll more about this in the [Interlude - What is a Shell](../../02-core-skills/12-what-is-a-shell/index.md) section.
 [^2]: Check [Chapter 4 - Becoming a Clipboard Gymnast](../../01-transitioning-to-the-shell/04-clipboard-gymnastics/index.md) for how to do this on a Linux or Windows machine.
 [^3]: Although always use tricks like this with caution! If we had a _different_ error, perhaps one we really do want to know about, we would lose the message in this case.
 [^4]: There is a very detailed explanation of this behaviour at https://linuxnewbieguide.org/21-and-understanding-other-shell-scripts-idioms/.

--- a/docs/02-core-skills/08-fly-on-the-command-line/index.md
+++ b/docs/02-core-skills/08-fly-on-the-command-line/index.md
@@ -241,5 +241,3 @@ There's a great cheat sheet on emacs readline commands at [readline.kablamo.org/
 We'll also see _GNU Readline_ later on when we talk about writing programs which work well in the shell.
 
 I hope that was useful! Being able to rapidly move around the command line will hopefully save you time and make you a more confident user of not just the shell, but many command line programs.
-
-[^1]: GIFs were made with [LICEcap](http://www.cockos.com/licecap/).

--- a/docs/02-core-skills/09-job-control/index.md
+++ b/docs/02-core-skills/09-job-control/index.md
@@ -120,7 +120,7 @@ Serving HTTP on 0.0.0.0 port 3000 ...
 [1]  + 7657 suspended  python -m SimpleHTTPServer 3000
 ```
 
-The process is currently in the foreground, so my shell is inactive. Hitting `Ctrl+Z` sends a 'suspend' signal to the process[^3], pausing it and moving it to the background.
+The process is currently in the foreground, so my shell is inactive. Hitting `Ctrl+Z` sends a 'suspend' signal to the process[^2], pausing it and moving it to the background.
 
 Let's dissect this:
 
@@ -161,7 +161,7 @@ $ %1 &
 
 In the same way ending a command with `&` runs it in the background, ending a job identifier with `&` _continues_ it in the background.
 
-There is at least one more way to move a job to the background[^4], but I have not yet found it useful in any scenarios, and it is overly complex to explain. See the footnote for details if you are interested.
+There is at least one more way to move a job to the background[^3], but I have not yet found it useful in any scenarios, and it is overly complex to explain. See the footnote for details if you are interested.
 
 ## Moving Background Jobs to the Foreground
 
@@ -199,7 +199,7 @@ $ jobs
 [1]  + suspended  python -m SimpleHTTPServer 3000
 ```
 
-There's my old web server. Note that even though it is suspended, it'll still be blocking the port it is serving on[^5]. The process is paused, but it is still holding onto all of the resources it is using.
+There's my old web server. Note that even though it is suspended, it'll still be blocking the port it is serving on[^4]. The process is paused, but it is still holding onto all of the resources it is using.
 
 Now that I know the job identifier (`%1` in this case), I can kill the job:
 
@@ -208,7 +208,7 @@ $ kill %1
 [1]  + 22843 terminated  python -m SimpleHTTPServer 3000
 ```
 
-*This is why job identifiers start with a percentage sign!* The `kill` command I have used is not a special job control command (like `bg` or `fg`). It is the normal `kill` command, which terminates a process. But shells that support job control can normally use a job identifier in place of a _process identifier_. So rather than working out what the process identifier is that I need to kill, I can just use the job identifier[^6].
+*This is why job identifiers start with a percentage sign!* The `kill` command I have used is not a special job control command (like `bg` or `fg`). It is the normal `kill` command, which terminates a process. But shells that support job control can normally use a job identifier in place of a _process identifier_. So rather than working out what the process identifier is that I need to kill, I can just use the job identifier[^5].
 
 ## Why You Shouldn't Use Jobs
 
@@ -222,7 +222,7 @@ This is what happens when I run a job, which just outputs text every second. It'
 
 Input is even more complex. If a job is _running_ in the background, but requires input, it will be _silently suspended_. This can cause confusion.
 
-Jobs _can_ be used in scripts but must be done so with caution and could easily confuse a consumer of the script if they leave background jobs hanging around, which cannot be easily cleaned up[^7].
+Jobs _can_ be used in scripts but must be done so with caution and could easily confuse a consumer of the script if they leave background jobs hanging around, which cannot be easily cleaned up[^6].
 
 Handling errors and exit codes for jobs can be problematic, causing confusion, poor error handling, or overly complex code.
 
@@ -276,12 +276,12 @@ If you want to find out more about the gory details of jobs, the best place to s
 
 [^1]: If you are not a heavy shell user, this might seem unlikely. But if you do a lot of work in shells, such as sysadmin, devops, or do your coding from a terminal, this happens all the time!
 
-[^3]: Technically, `SIGTSTP` signal - which is 'TTY stop'. If you have always wondered about the 'TTY' acronym, check the chapter, [Interlude: Understanding the Shell](../../02-core-skills/10-understanding-commands/index.md).
+[^2]: Technically, `SIGTSTP` signal - which is 'TTY stop'. If you have always wondered about the 'TTY' acronym, check the chapter, [Interlude: Understanding the Shell](../../02-core-skills/10-understanding-commands/index.md).
 
-[^4]: The alternative method is to use `Ctrl+Y`, which will send a _delayed interrupt_, which will continue to run the process until it tries to read from `stdin`. At this point, the job is suspended and the control given to the shell. The operator can then use `bg` or `kill` or `fg` to either move to the background, stop the process, or keep in the foreground as preferred. See: https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Job-Control
+[^3]: The alternative method is to use `Ctrl+Y`, which will send a _delayed interrupt_, which will continue to run the process until it tries to read from `stdin`. At this point, the job is suspended and the control given to the shell. The operator can then use `bg` or `kill` or `fg` to either move to the background, stop the process, or keep in the foreground as preferred. See: https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Job-Control
 
-[^5]: Another super-useful snippet: `lsof -i -P -n | grep 8000` to find any process that has a given port open. Another one for the aliases chapter!
+[^4]: Another super-useful snippet: `lsof -i -P -n | grep 8000` to find any process that has a given port open. Another one for the aliases chapter!
 
-[^6]: There are times this is needed. If a job runs _many processes_ - for example, by running a pipeline - the process identifier will change as the command moves from one stage of the pipeline to the next. The job identifier will remain constant. Remember, a job is a shell _command_, so could run many processes.
+[^5]: There are times this is needed. If a job runs _many processes_ - for example, by running a pipeline - the process identifier will change as the command moves from one stage of the pipeline to the next. The job identifier will remain constant. Remember, a job is a shell _command_, so could run many processes.
 
-[^7]: To see how bad this can be, create a script that starts jobs, then run it. Then run the `jobs` command to see what is running. The output might surprise you!
+[^6]: To see how bad this can be, create a script that starts jobs, then run it. Then run the `jobs` command to see what is running. The output might surprise you!

--- a/docs/02-core-skills/12-what-is-a-shell/index.md
+++ b/docs/02-core-skills/12-what-is-a-shell/index.md
@@ -212,7 +212,7 @@ In this example, we have:
 - iTerm2 as the terminal program
 - `tmux` running as a 'terminal multiplexer' (see [Effective Shell: Terminal Multiplexers](https://github.com/dwmkerr/effective-shell#coming-soon))
 - `zsh` (Z Shell) as the shell program, using 'oh my zsh', which is easily recognised by the `%` sign in the command prompt.
-- A customised command line, which shows the user and folder on one line, with only the `%` symbol below, to leave lots of space for the input commands[^10].
+- A customised command line, which shows the user and folder on one line, with only the `%` symbol below, to leave lots of space for the input commands[^9].
 
 #### Example: Bash
 

--- a/docs/04-shell-scripting/18-shell-script-essentials/index.md
+++ b/docs/04-shell-scripting/18-shell-script-essentials/index.md
@@ -192,7 +192,7 @@ If the `chmod` command looks unfamiliar then check the [Understanding Commands](
 ~/scripts/common.v1.sh
 ```
 
-There is a problem with this approach though. How this file is executed is going to vary depending on how your system is set up[^3]. For example, if you are using Bash, then the script will run in a new instance of the Bash shell. However, if you are using the Z shell, then the script will most likely run in the `sh` program (and depending on your system, this program might just be a link to _another_ type of shell).
+There is a problem with this approach though. How this file is executed is going to vary depending on how your system is set up[^2]. For example, if you are using Bash, then the script will run in a new instance of the Bash shell. However, if you are using the Z shell, then the script will most likely run in the `sh` program (and depending on your system, this program might just be a link to _another_ type of shell).
 
 We want to avoid any ambiguity and be explicit about _what_ program should run our script. We can do this using a special construct called a _shebang_.
 
@@ -404,7 +404,7 @@ common commands:
 
 This works because when the shell sees a command, it searches through the folders in the $PATH environment variable to find out where the command is. And the `/usr/bin/local` folder is in this list of paths.
 
-Why do we use the `/usr/bin/local` folder rather than the `/usr/bin` folder? This is just a convention. In general, the `/usr/bin` folder is for commands which are installed with package manager tools like `apt` or Homebrew (on MacOS). The `/usr/local/bin` folder is used for commands which you create for yourself on your local machine and manage yourself[^4].
+Why do we use the `/usr/bin/local` folder rather than the `/usr/bin` folder? This is just a convention. In general, the `/usr/bin` folder is for commands which are installed with package manager tools like `apt` or Homebrew (on MacOS). The `/usr/local/bin` folder is used for commands which you create for yourself on your local machine and manage yourself[^3].
 
 ## Summary
 
@@ -496,5 +496,5 @@ Why the numeric sort? If we didn't sort numerically and instead performed the de
 This is a lexographic sort - the line starting with 13 comes after the line starting with 2. We want to sort by the value of the number.
 
 [^1]: The path to the shell history file is normally available in the `$HISTFILE` environment variable. However, in a non-interactive shell this variable is not set (and when we run a shell script, it is run in a non-interactive shell). We'll see more about interactive and non-interactive shells later, this is just a note in case you are wondering why we don't use the `$HISTFILE` variable or `history` command!
-[^3]: Try putting the command `pstree -p $$` in a shell script and running the script - you'll see exactly what process is run.
-[^4]: If you want to know more about these folders and the conventions behind them then check back soon, I am going to be adding an entire section on Linux Fundamentals, and one of the chapters will specifically be on the Linux Filesystem. This will cover 'The Linux Filesystem Hierarchy Standard' which defines how folders like this should be used.
+[^2]: Try putting the command `pstree -p $$` in a shell script and running the script - you'll see exactly what process is run.
+[^3]: If you want to know more about these folders and the conventions behind them then check back soon, I am going to be adding an entire section on Linux Fundamentals, and one of the chapters will specifically be on the Linux Filesystem. This will cover 'The Linux Filesystem Hierarchy Standard' which defines how folders like this should be used.

--- a/docs/04-shell-scripting/21-loops-and-working-with-files-and-folders/index.md
+++ b/docs/04-shell-scripting/21-loops-and-working-with-files-and-folders/index.md
@@ -219,7 +219,7 @@ do
 done
 ```
 
-The `shopt` (_set and unset shell option_)<!--index--> command is used to configure shell options. We will be looking at shell options in detail in Part 5. The 'nullglob' option changes the shell behaviour so that if a wildcard pattern does not match any results, it is set to null string[^1].
+The `shopt` (_set and unset shell option_)<!--index--> command is used to configure shell options. We will be looking at shell options in detail in Part 5. The 'nullglob' option changes the shell behaviour so that if a wildcard pattern does not match any results, it is set to null string[^2].
 
 The second way we can deal with this problem is to just use a `test` command. I think that this is actually far more readable than the `shopt` solution. Here's how it would look:
 
@@ -299,7 +299,7 @@ This will cover you in most cases. However, this method is not ideal for a numbe
 
 1. It is quite verbose - we have to store the current value of `$IFS` and then reset it later
 2. It is not quite foolproof - filenames on some systems can have a newline character and this script would fail for those files
-3. We have to use the complex looking 'ANSI C Quoting' syntax to set `$IFS` to a newline[^2]
+3. We have to use the complex looking 'ANSI C Quoting' syntax to set `$IFS` to a newline[^3]
 4. If the reader doesn't know what `$IFS` is then the entire script will be difficult to follow
 
 The `$IFS` variable can be complex to work with and discussed at the end of the chapter.
@@ -814,5 +814,5 @@ Word: one two three
 If you want to use more Posix-like functionality then you can set the `SH_WORD_SPLIT` parameter. You can find out more about this parameter by running `man zsh` and searching for `SH_WORD_SPLIT`.
 
 [^1]: If we had put quotes around the wildcard text it would _not_ be expanded - check the section on 'Quoting' in [Chapter 19 - Variables, Reading Input, and Mathematics](../../04-shell-scripting/19-variables-reading-input-and-mathematics/index.md) if you need a refresher on this.
-[^2]: ANSI C Quoting is described in the 'Quoting' section in [Chapter 19 - Variables, Reading Input, and Mathematics](../../04-shell-scripting/19-variables-reading-input-and-mathematics/index.md)
 [^2]: There is a good reason for this. Would you prefer `ls *.nothing-here` to show a warning that _*.nothing-here_ doesn't exist or show the result of `ls` - which lists the current directory! This is discussed in more detail on this Stack Overflow thread: https://unix.stackexchange.com/questions/204803/why-is-nullglob-not-default
+[^3]: ANSI C Quoting is described in the 'Quoting' section in [Chapter 19 - Variables, Reading Input, and Mathematics](../../04-shell-scripting/19-variables-reading-input-and-mathematics/index.md)


### PR DESCRIPTION
When the text skips footnote-references (like chapter 02-core-skills/09-job-control) the numbers in the text are according to what is written in the source while the actual footnotes are strictly ascending without skipping numbers. This leads to a somewhat confusing situation where footnote 7 in the text is actually footnote 6 (see screenshots).

I also fixed a Link in 02-core-skills/07-thinking-in-pipelines as the referenced chapter now seems to exist, please make sure this points to the correct chapter.

Text:
![grafik](https://user-images.githubusercontent.com/7615963/182033832-bfb976a3-bd4a-42b1-9103-258970e6b5e0.png)

Footnote:
![grafik](https://user-images.githubusercontent.com/7615963/182033894-014bf506-7683-4d2d-acd9-14af58253a65.png)
