### PR TITLE
Correct vim command for moving to the first occurance of open paren

### DIFF
--- a/docs/06-advanced-techniques/32-a-vim-crash-course/index.mdx
+++ b/docs/06-advanced-techniques/32-a-vim-crash-course/index.mdx
@@ -428,7 +428,7 @@ If you use an open bracket or brace, a space is added before and after the text 
 
 | Keystrokes                                   | Output                                                 |
 |----------------------------------------------|--------------------------------------------------------|
-| <AnnotatedCommand annotation="Go to first open bracket">g(</AnnotatedCommand> | <CodeBlock language="python">def search_for_word<Caret>(</Caret>word):</CodeBlock> |
+| <AnnotatedCommand annotation="Go to first open bracket">f(</AnnotatedCommand> | <CodeBlock language="python">def search_for_word<Caret>(</Caret>word):</CodeBlock> |
 | <AnnotatedCommand annotation="Change in brackets">ci)</AnnotatedCommand> | <CodeBlock language="python">def search_for_word<Caret>(</Caret>):</CodeBlock> |
 | <AnnotatedCommand annotation="Enter text, return to Command Mode">word = "default"&lt;C-c&gt;</AnnotatedCommand> | <CodeBlock language="python">def search_for_word(word = "default"<Caret>)</Caret>:</CodeBlock> |
 | <AnnotatedCommand annotation="Change a quotes">ca"</AnnotatedCommand> | <CodeBlock language="python">def search_for_word(word = <Caret>)</Caret>:</CodeBlock> |


### PR DESCRIPTION
I believe `g(` was a typo. `f(` is what is used to move **f**orward to `(`.

Also, this step could be removed entirely as the next command, `ci)` would move to the first set of parens on the line anyway.