### PR TITLE
feat: add Google Tag Manager for Amazon click tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -241,6 +241,7 @@ const config = {
   headTags: [
     {
       tagName: 'script',
+      attributes: {},
       innerHTML: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
## Summary
- Add GTM container (GTM-WS7KMPTS) to track clicks on Amazon affiliate links
- GTM is configured with a GA4 Event tag to send `amazon_click` events when users click on `amzn.to` links