### PR TITLE
fix: clean build dir in pre-push hook to avoid EEXIST errors

### DIFF
--- a/.claude/hooks/pre-push-checks.sh
+++ b/.claude/hooks/pre-push-checks.sh
@@ -21,8 +21,9 @@ if echo "$cmd" | grep -Eq '\bgit\s+push\s+.*--force'; then
   exit 2
 fi
 
-# Run build before push
+# Run build before push (clean first to avoid redirect plugin EEXIST errors)
 echo "Running build before push..." >&2
+rm -rf build
 if ! npm run build >&2 2>&1; then
   echo "Build failed. Fix errors before pushing." >&2
   exit 2


### PR DESCRIPTION
## Summary
- Adds `rm -rf build` before `npm run build` in the pre-push hook
- Prevents the Docusaurus redirect plugin from failing with `EEXIST` when a stale `build/` directory exists from a previous build

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/dwmkerr/effective-shell/423?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->