### PR TITLE
feat: add block-no-verify to prevent AI agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          },
+          {
+            "type": "command",
             "command": ".claude/hooks/pre-commit-build.sh",
             "timeout": 120
           },


### PR DESCRIPTION
Closes #425. Adds block-no-verify@1.1.2 as the first PreToolUse hook in .claude/settings.json to prevent AI agents from bypassing hooks. The existing pre-commit-build.sh and pre-push-checks.sh hooks are preserved.