### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
             "command": ".claude/hooks/pre-commit-build.sh",
             "timeout": 120
           },


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as an additional hook in the existing `PreToolUse` Bash hook list in `.claude/settings.json`.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing `pre-commit-build.sh` hook is preserved and block-no-verify is prepended to run first.

Closes #427

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
