### PR TITLE
docs: extend errata + fix man re_pattern and add sed g flag explanation

### DIFF
--- a/docs/02-manipulating-text/13-regex-essentials/index.mdx
+++ b/docs/02-manipulating-text/13-regex-essentials/index.mdx
@@ -291,7 +291,7 @@ We've seen quite a few character sets and metacharacters, here's a quick referen
 | `\d` | Any 'digit' character `[0-9]`. |
 | `\D` | Any non 'digit' character. |
 
-There are many other metacharacters, you can find more in the manpage `man re_pattern`
+There are many other metacharacters. You can find more in the manpage `man re_format` (macOS, BSD) or `man 7 regex` (Linux).
 
 ### Building Regexes - Anchors
 

--- a/docs/02-manipulating-text/16-advanced-text-manipulation/index.mdx
+++ b/docs/02-manipulating-text/16-advanced-text-manipulation/index.mdx
@@ -91,13 +91,17 @@ Just as we saw in [Chapter 13 - Get to Grips with Grep](../../part-3-manipulatin
 :::tip Basic and Extended Regular Expressions
 
 
-If you are not sure about the difference between Basic and Extended Regular Expressions, you can use the:
+If you are not sure about the difference between Basic and Extended Regular Expressions, you can read the regular expression manpage. On macOS or BSD use:
 
 ```
-man re_pattern
+man re_format
 ```
 
-Command to get detailed documentation.
+On Linux use:
+
+```
+man 7 regex
+```
 
 :::
 

--- a/docs/03-shell-scripting/19-variables-reading-input-and-mathematics/index.mdx
+++ b/docs/03-shell-scripting/19-variables-reading-input-and-mathematics/index.mdx
@@ -124,6 +124,8 @@ masked_password=$(echo "$password" | sed 's/./*/g')
 echo "Setting password '${masked_password}'..."
 ```
 
+The `g` flag at the end of the `sed` expression stands for *global* - without it, `sed` would only replace the first character on each line. With `g`, every character matched by the pattern is replaced, masking the entire password.
+
 The output of this script will look like this:
 
 ```

--- a/docs/xx-appendices/errata.md
+++ b/docs/xx-appendices/errata.md
@@ -23,6 +23,10 @@ The text presents `bind -p` as an "alternative form" of `bindkey`. They are not 
 
 A shell-agnostic alternative for inspecting terminal-level key bindings is `stty -a`.
 
+### Page 20 (and Appendix B) — Clipboard / working with the system clipboard
+
+The chapter introduces working with the system clipboard from the shell, with further detail in Appendix B. Clipboard handling varies significantly across platforms — Cygwin, WSL, OpenBSD, macOS, and various Linux desktop environments each use different tools and have different limitations. The goal of the book is to free your hands from the mouse and work more productively from the keyboard, not to send you down a rabbit hole tracking down a clipboard utility. If the clipboard examples don't work on your system, it is safe to skip them — none of the rest of the book depends on them.
+
 ## Chapter 3 — Thinking in Pipelines
 
 ### Page 19 — Ctrl-D
@@ -32,6 +36,26 @@ A shell-agnostic alternative for inspecting terminal-level key bindings is `stty
 ### Page 19 — `wc` flag typo
 
 One print run shows `wc -1` (digit one) instead of `wc -l` (lowercase L) for the line-count flag. Page 20 prints correctly. This is a print typo only; the website is correct.
+
+## Chapter 4 — Regular Expression Essentials
+
+### Page 51 — `man re_pattern`
+
+The text refers to `man re_pattern` for further regex documentation. No manpage with that name exists on any common platform. The correct references are `man re_format` on macOS and BSD, and `man 7 regex` on Linux. The same incorrect reference appears in Chapter 7 (page 85) and the appendix manpage list — all three locations have been corrected on the website.
+
+### Regex flavours — regex101 vs BRE / ERE / PCRE
+
+The chapter teaches regular expressions using [regex101.com](https://regex101.com) as the primary reference tool. regex101 defaults to a PCRE-compatible engine. Several subsequent chapters cover tools that use different regex flavours:
+
+| Tool                 | Flavour                              |
+|----------------------|--------------------------------------|
+| `grep`               | Basic Regular Expressions (BRE)      |
+| `grep -E`, `egrep`   | Extended Regular Expressions (ERE)   |
+| `sed`                | BRE (ERE with `-E`)                  |
+| `awk`                | ERE                                  |
+| `perl`, `pcregrep`   | PCRE                                 |
+
+Constructs such as `\d`, unescaped `+`, `?`, and `{n,m}` work in regex101 but behave differently in `grep` BRE. The chapter has a short note on tool differences toward the end, but readers building a mental model around regex101 will hit surprises the first time they use `grep` or `sed`. A flavour overview has been added near the start of the chapter to make this explicit.
 
 ## Chapter 7 — Get to Grips with `sed`
 
@@ -115,19 +139,17 @@ tail ~/.bash_history -n 1000 |
 
 This is a style point rather than an error — both forms run identically. The website examples use the implicit form in long pipelines.
 
-## Chapter 13 — Regular Expression Essentials
+## Chapter 10 — Variables, Reading Input, and Mathematics
 
-The chapter teaches regular expressions using [regex101.com](https://regex101.com) as the primary reference tool. regex101 defaults to a PCRE-compatible engine. Several subsequent chapters cover tools that use different regex flavours:
+### Page 134 — `g` flag in `sed`
 
-| Tool             | Flavour                              |
-|------------------|--------------------------------------|
-| `grep`           | Basic Regular Expressions (BRE)      |
-| `grep -E`, `egrep` | Extended Regular Expressions (ERE) |
-| `sed`            | BRE (ERE with `-E`)                  |
-| `awk`            | ERE                                  |
-| `perl`, `pcregrep` | PCRE                              |
+The example `sed 's/./*/g'` is shown without explaining the `g` flag. The book usually unpacks small details like this. The `g` stands for *global*: without it, `sed` only replaces the first match on each line. With `g`, every match on the line is replaced — which is what makes the password-masking example mask every character rather than just the first one. The website now includes a short explanation alongside the example.
 
-Constructs such as `\d`, unescaped `+`, `?`, and `{n,m}` work in regex101 but behave differently in `grep` BRE. The chapter has a short note on tool differences toward the end, but readers building a mental model around regex101 will hit surprises the first time they use `grep` or `sed`. A flavour overview has been added near the start of the chapter to make this explicit.
+## Chapter 24 — Master the Multiplexer (tmux)
+
+### Page 365 — tmux on Cygwin
+
+The text suggests `tmux` is not available on Cygwin. A `tmux` package is in fact available through the Cygwin installer and works well for most of the functionality covered in the chapter. There are some minor limitations compared to a native Linux or BSD environment, but Cygwin users do not need to skip this chapter.
 
 ---
 

--- a/docs/xx-appendices/essential-manpages.md
+++ b/docs/xx-appendices/essential-manpages.md
@@ -2,10 +2,9 @@
 
 As an appendix, or printed reference, list of the top ten manpages?
 
-- `man re_pattern` - basic and extended regex patterns
+- `man re_format` (macOS, BSD) or `man 7 regex` (Linux) - basic and extended regex patterns
 - `man test` is an excellent way to quickly check common tests (existence of a file etc)
 - `man set` is super useful when checking options like `set -ex` in scripts
-- `man re_format`
 - `man getopt`
 - `man XXX` show signal commands (`Ctrl+V` etc)
 - `man bash` search for `ARITHMETIC\ EVALUATION` to find how arithmetic operators work in bash


### PR DESCRIPTION
## Summary
- Extends `docs/xx-appendices/errata.md` with four further reader-reported catches: clipboard portability note (Ch 2 / Appendix B), `man re_pattern` correction (Ch 4 / Ch 7 / appendix), `sed` `g` flag explanation (Ch 10), and tmux on Cygwin clarification (Ch 24).
- Replaces `man re_pattern` with `man re_format` (macOS/BSD) and `man 7 regex` (Linux) in the three places it appeared on the site: regex essentials, advanced text manipulation, and the essential-manpages appendix.
- Adds a short explanation of the `g` (global) flag next to the `sed 's/./*/g'` password-masking example in the variables chapter.
- Reorganises the errata page so entries are ordered by chapter and page.

## Test plan
- [x] `npm run build` passes
- [ ] Errata page renders correctly in sidebar under Appendices
- [ ] Regex chapter and advanced text manipulation chapter show the corrected manpage references
- [ ] Variables chapter shows the `g` flag explanation under the password example