### PR TITLE
docs: sync Fly on the Command Line chapter with errata + fix Claude Code shortcuts

### DIFF
--- a/.claude/hooks/pre-commit-build.sh
+++ b/.claude/hooks/pre-commit-build.sh
@@ -16,7 +16,8 @@ fi
 
 echo "Running build before commit..." >&2
 
-# Run the build
+# Clean first to avoid redirect plugin EEXIST errors on a stale build dir
+rm -rf build
 if ! npm run build 2>&1; then
   echo "Build failed. Fix errors before committing." >&2
   exit 2

--- a/docs/01-core-skills/01-fly-on-the-command-line/index.mdx
+++ b/docs/01-core-skills/01-fly-on-the-command-line/index.mdx
@@ -227,6 +227,10 @@ The shell will search the previous commands for the term file, jumping farther b
 
 Press <kbd>Enter</kbd> to get back to the regular prompt. Searching forward with <kbd>Ctrl</kbd>-<kbd>S</kbd> works in much the same way.
 
+:::note
+On many terminals, pressing <kbd>Ctrl</kbd>-<kbd>S</kbd> won't search forward — instead it triggers *XOFF*, a legacy flow-control signal that freezes terminal output and makes the shell appear to hang. If this happens, press <kbd>Ctrl</kbd>-<kbd>Q</kbd> (*XON*) to unfreeze it. To free up <kbd>Ctrl</kbd>-<kbd>S</kbd> for forward search, disable flow control with `stty -ixon`.
+:::
+
 If your code lines are long, these two shortcuts are often the fastest ways to move to the desired location in the current line. You can also use them to quickly search through your entire command history. For example, to find your last mkdir ("make directory") command, press <kbd>Ctrl</kbd>-<kbd>R</kbd>, enter `mkdir`, and then press <kbd>Ctrl</kbd>-<kbd>R</kbd> again to search backward through all mkdir commands stored in your history.
 
 A quick way to test this is also to search for echo. If you've been using the echo command to enter the quote as in the earlier examples, it should be the first result that the reverse search finds.
@@ -325,6 +329,10 @@ There are a few other shortcuts that, while they don't fit into the categories w
 
 The shortcut <kbd>Ctrl</kbd>-<kbd>L</kbd> clears the screen but doesn't affect anything unexecuted in your current line. This is very helpful if you have a lot of "noisy" output on the screen and want to clean it up.
 
+:::note
+<kbd>Ctrl</kbd>-<kbd>L</kbd> redraws the prompt at the top of the visible area — it doesn't wipe the scrollback buffer, so earlier output is still accessible by scrolling up. The `clear` command behaves the same way by default. To clear the scrollback too, use `clear -x` or `printf '\033[3J'`.
+:::
+
 ![Clearing the screen](./images/clear-screen.gif)
 
 *Using <kbd>Ctrl</kbd>-<kbd>L</kbd> to clear the screen*
@@ -411,7 +419,16 @@ $ bindkey
 ...
 ```
 
-This is an extremely useful command if you forget a specific keyboard shortcut or even if you just want to see the shortcuts available to you. If bindkey doesn't work for you, try using the alternative form bind -p.
+This is an extremely useful command if you forget a specific keyboard shortcut or even if you just want to see the shortcuts available to you.
+
+:::note
+`bindkey` is a Zsh builtin and won't work in Bash. `bind` and `bindkey` are *different* builtins, not alternative forms of the same command. To list the current bindings:
+
+- **Bash:** `bind -p` (and `help bind` for documentation)
+- **Zsh:** `bindkey` (and `man zshzle` for documentation)
+
+Neither has a dedicated man page — `man bind` lands on the C socket function, not the shell builtin. A shell-agnostic way to inspect terminal-level key bindings is `stty -a`.
+:::
 
 ### Transpose Text
 
@@ -450,24 +467,24 @@ Most of the keyboard shortcuts shown in this chapter work in exactly the same wa
 | <kbd>Ctrl</kbd>+<kbd>L</kbd> | Clear screen |
 | <kbd>Ctrl</kbd>+<kbd>G</kbd> | Edit in Place |
 
-There are many other Claude Code specific keyboard shortcuts and some of the most useful to consider commiting to memory are:
+There are many other Claude Code specific keyboard shortcuts and some of the most useful to consider committing to memory are:
 
 | Shortcut | Action |
 |----------|--------|
-| <kbd>Ctrl</kbd>+<kbd>G</kbd> | Open default text editor |
-| <kbd>Ctrl</kbd>+<kbd>S</kbd> | Stash prompt—stores current input, press again to restore |
 | <kbd>Alt</kbd>+<kbd>T</kbd> | Toggle extended thinking mode |
-| <kbd>Ctrl</kbd>+<kbd>O</kbd> | Toggle verbose output |
+| <kbd>Ctrl</kbd>+<kbd>O</kbd> | Toggle the transcript viewer (detailed tool usage) |
 | <kbd>Ctrl</kbd>+<kbd>V</kbd> | Paste image from clipboard |
-| <kbd>Ctrl</kbd>+<kbd>B</kbd> | Background running tasks |
-| <kbd>Ctrl</kbd>+<kbd>C</kbd> | Cancel current input or generation |
-| <kbd>Ctrl</kbd>+<kbd>F</kbd> | Kill all background agents |
-| <kbd>Ctrl</kbd>+<kbd>T</kbd> | Toggle task list |
-| <kbd>Alt</kbd>+<kbd>M</kbd> | Toggle permission modes |
+| <kbd>Ctrl</kbd>+<kbd>B</kbd> | Background a running task |
+| <kbd>Ctrl</kbd>+<kbd>C</kbd> | Interrupt, or clear the input |
+| <kbd>Ctrl</kbd>+<kbd>X</kbd> <kbd>Ctrl</kbd>+<kbd>K</kbd> | Stop all background subagents (press twice to confirm) |
+| <kbd>Ctrl</kbd>+<kbd>T</kbd> | Toggle Claude's task list |
+| <kbd>Shift</kbd>+<kbd>Tab</kbd> | Cycle permission modes |
 | <kbd>Alt</kbd>+<kbd>P</kbd> | Switch model |
-| <kbd>Esc</kbd>, <kbd>Esc</kbd> | Rewind or summarize conversation |
+| <kbd>Ctrl</kbd>+<kbd>Y</kbd> | Paste text deleted with <kbd>Ctrl</kbd>+<kbd>K</kbd> / <kbd>U</kbd> / <kbd>W</kbd> |
+| <kbd>Ctrl</kbd>+<kbd>J</kbd> | Insert a newline without submitting |
+| <kbd>Esc</kbd>, <kbd>Esc</kbd> | Clear the input draft, or rewind the conversation |
 
-Claude Code also supports vim mode, which you can enable with the `/vim` command. We'll cover vim editing in detail in [A Vim Crash Course](/part-6-advanced-techniques/a-vim-crash-course/). For a complete reference of all Claude Code shortcuts, see the [Interactive Mode documentation](https://code.claude.com/docs/en/interactive-mode).
+Claude Code also supports vim-style editing, which you can enable via `/config` → Editor mode. We'll cover vim editing in detail in [A Vim Crash Course](/part-6-advanced-techniques/a-vim-crash-course/). For a complete reference of all Claude Code shortcuts, see the [Interactive Mode documentation](https://code.claude.com/docs/en/interactive-mode).
 
 Under the hood, the reason that many of these shortcuts work consistently in tools like Claude Code is that they use GNU Readline - which we'll look at next.
 

--- a/tasks/migration/README.md
+++ b/tasks/migration/README.md
@@ -93,9 +93,29 @@ These website sections are not in the published book and should be reorganized:
 | [#404](https://github.com/dwmkerr/effective-shell/issues/404) | Book uses numbered reference annotations in code blocks (e.g., ①②③) with explanations below. Need custom component. |
 | [#405](https://github.com/dwmkerr/effective-shell/issues/405) | Book references other chapters that may not be migrated yet. Backfill internal links after migration complete. |
 
+## Content Audit (2026-07)
+
+Automated prose-similarity audit of each online chapter vs its print manuscript
+source (`tasks/migration/audit.py`). Online = old blog-era text; print is the
+authoritative version to backfill. Word-count delta is a stronger signal than
+raw similarity — where print ≫ online, the online is missing content.
+
+| Bucket | Chapters | Action |
+|--------|----------|--------|
+| **Already print** (sim ≥ .75) | ch01, ch04, ch05, ch14, ch16, ch17, ch20, ch23 | errata-sync only |
+| **Real backfill** (online ~½ of print) | **ch02, ch15, ch18** | replace with print text |
+| **Partial / reconcile** | ch03, ch06, ch07, ch08, ch09, ch11, ch12, ch13, ch19, ch21, ch22, ch24 | section-by-section |
+| **Broken source** | ch10 | manuscript extraction is a 102-word stub — re-extract first |
+| **Bonus → Part VI** | job-control, understanding-commands, what-is-a-shell | keep website-only |
+
+Backfill order (biggest gap first): ch02 → ch15 → ch18 → ch06 → ch13 → …
+
+Note: the mapping table above uses pre-#411 dir numbers; actual dirs were
+renumbered (e.g. `08-fly` → `01-fly`). See the audit script for the live map.
+
 ## Progress Tracking
 
-- [ ] Phase 1: Content audit complete
+- [x] Phase 1: Content audit complete (2026-07)
 - [ ] Phase 2: Part I chapters migrated
 - [ ] Phase 3: Part II chapters migrated
 - [ ] Phase 4: Part III chapters migrated

--- a/tasks/migration/audit.py
+++ b/tasks/migration/audit.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Audit: how close is each ONLINE chapter to its PRINT manuscript source?
+
+High similarity  -> already backfilled with print text (done).
+Low  similarity  -> still the old blog-era text (needs backfill).
+No manuscript    -> website-only bonus chapter (Part VI).
+
+Compares normalised plain-text prose (markup stripped) with difflib. Not exact,
+but cleanly separates "already matches print" from "diverged / old".
+"""
+import re
+import difflib
+from pathlib import Path
+
+BOOK = Path.home() / "repos/github/dwmkerr/effective-shell-book/migration/chapters"
+DOCS = Path("/Users/Dave_Kerr/repos/github/dwmkerr/effective-shell/docs")
+
+# manuscript file  ->  online index.mdx (matched by topic; dirs renumbered by #411)
+PAIRS = {
+    "ch01-flying-on-the-command-line.md": "01-core-skills/01-fly-on-the-command-line",
+    "ch02-thinking-in-pipelines.md": "01-core-skills/07-thinking-in-pipelines",
+    "ch03-finding-files-and-folders.md": "01-core-skills/11-finding-files",
+    "ch04-regular-expression-essentials.md": "02-manipulating-text/13-regex-essentials",
+    "ch05-getting-to-grips-with-grep.md": "02-manipulating-text/14-get-to-grips-with-grep",
+    "ch06-slicing-and-dicing-text.md": "02-manipulating-text/15-slice-and-dice-text",
+    "ch07-advanced-text-manipulation-with-sed.md": "02-manipulating-text/16-advanced-text-manipulation",
+    "ch08-building-commands-on-the-fly.md": "02-manipulating-text/17-build-commands-on-the-fly",
+    "ch09-shell-script-fundamentals.md": "03-shell-scripting/18-shell-script-essentials",
+    "ch10-using-variables-to-store-read-and-manipulate-data.md": "03-shell-scripting/19-variables-reading-input-and-mathematics",
+    "ch11-mastering-conditional-logic.md": "03-shell-scripting/20-mastering-conditional-logic",
+    "ch12-using-loops-with-files-and-folders.md": "03-shell-scripting/21-loops-and-working-with-files-and-folders",
+    "ch13-functions-parameters-and-error-handling.md": "03-shell-scripting/22-functions-parameters-and-error-handling",
+    "ch14-useful-patterns-for-shell-scripts.md": "03-shell-scripting/23-useful-patterns-for-shell-scripts",
+    "ch15-configuring-your-shell.md": "04-building-your-toolkit/24-configuring-the-shell",
+    "ch16-customizing-your-command-prompt.md": "04-building-your-toolkit/25-customising-your-command-prompt",
+    "ch17-managing-your-dot-files.md": "04-building-your-toolkit/26-managing-your-dotfiles",
+    "ch18-controlling-changes-with-git.md": "04-building-your-toolkit/27-controlling-changes-with-git",
+    "ch19-managing-remote-git-repositories.md": "04-building-your-toolkit/28-managing-remote-git-repositories",
+    "ch20-shell-expansion.md": "05-advanced-techniques/29-understanding-shell-expansion",
+    "ch21-alternatives-to-shell-scripting.md": "05-advanced-techniques/30-how-to-avoid-scripting",
+    "ch22-the-secure-shell.md": "05-advanced-techniques/31-the-secure-shell",
+    "ch23-the-power-of-terminal-editors.md": "05-advanced-techniques/32-a-vim-crash-course",
+    "ch24-mastering-the-multiplexer.md": "05-advanced-techniques/33-master-the-multiplexer",
+}
+
+# online dirs with no print counterpart -> bonus (Part VI)
+BONUS = ["01-core-skills/09-job-control", "01-core-skills/10-understanding-commands",
+         "01-core-skills/12-what-is-a-shell"]
+
+
+def norm(text):
+    text = re.sub(r"^---.*?---", "", text, flags=re.S)          # frontmatter
+    text = re.sub(r"^import .*$", "", text, flags=re.M)          # mdx imports
+    text = re.sub(r"<[^>]+>", " ", text)                        # jsx/html tags
+    text = re.sub(r"```.*?```", " ", text, flags=re.S)          # code blocks
+    text = re.sub(r"[\{\}\[\]\(\)#*`_>|\\$\"'″′]", " ", text)  # markup+smart quotes
+    text = re.sub(r"\{\.smallcaps\}", " ", text)
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return " ".join(words)
+
+
+def wordset_overlap(a, b):
+    sa, sb = set(a.split()), set(b.split())
+    return len(sa & sb) / max(len(sa | sb), 1)
+
+
+def classify(ratio):
+    if ratio >= 0.75:
+        return "ALREADY-PRINT"
+    if ratio >= 0.55:
+        return "PARTIAL/CHECK"
+    return "OLD-BACKFILL"
+
+
+print(f"{'CHAPTER':<45} {'ONLINE WORDS':>12} {'PRINT WORDS':>11} {'SIM':>6}  VERDICT")
+print("-" * 92)
+rows = []
+for man, online in PAIRS.items():
+    mp = BOOK / man
+    op = DOCS / online / "index.mdx"
+    if not mp.exists() or not op.exists():
+        print(f"{man[:44]:<45} {'--':>12} {'--':>11} {'--':>6}  MISSING FILE")
+        continue
+    mn, on = norm(mp.read_text()), norm(op.read_text())
+    ratio = difflib.SequenceMatcher(None, on, mn).quick_ratio()
+    overlap = wordset_overlap(on, mn)
+    sim = round((ratio + overlap) / 2, 2)
+    rows.append((sim, man, online))
+    print(f"{man[:44]:<45} {len(on.split()):>12} {len(mn.split()):>11} {sim:>6}  {classify(sim)}")
+
+print("\nBONUS (website-only, no print source -> Part VI):")
+for b in BONUS:
+    p = DOCS / b / "index.mdx"
+    n = len(norm(p.read_text()).split()) if p.exists() else 0
+    print(f"  {b:<45} {n:>6} words")
+
+print("\nBackfill priority (lowest similarity first):")
+for sim, man, _ in sorted(rows):
+    if sim < 0.75:
+        print(f"  {sim:>5}  {man}")


### PR DESCRIPTION
## Summary
- Add errata callouts to the Fly on the Command Line chapter (Ctrl-S/XOFF flow control, `bindkey` vs `bind`, Ctrl-L scrollback) — these were logged in the errata appendix but not yet on the page.
- Correct the "Flying in Claude Code" shortcut table against the official Claude Code docs: fix `Ctrl+X Ctrl+K` (stop subagents), `Shift+Tab` (cycle permission modes), add `Ctrl+Y`/`Ctrl+J`, remove unverified `Ctrl+S`/`Ctrl+F`, and vim mode via `/config`.
- Add a migration content audit (`tasks/migration/audit.py`) comparing each online chapter to its print manuscript, with results recorded in the migration README.
- Fix the pre-commit build hook to clean the build dir first (avoids EEXIST on a stale build, same fix already applied to pre-push).